### PR TITLE
Add bolt.diy as an optional frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,9 @@ test_results*
 frontend/build
 frontend/dist
 
+# bolt.diy frontend
+bolt_diy/
+
 # misc
 .DS_Store
 .env.local

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DEFAULT_MODEL = "gpt-4o"
 CONFIG_FILE = config.toml
 PRE_COMMIT_CONFIG_PATH = "./dev_config/python/.pre-commit-config.yaml"
 PYTHON_VERSION = 3.12
+FRONTEND_TYPE ?= "DEFAULT"  # Options: DEFAULT, BOLT_DIY
 
 # ANSI color codes
 GREEN=$(shell tput -Txterm setaf 2)
@@ -21,312 +22,332 @@ RESET=$(shell tput -Txterm sgr0)
 
 # Build
 build:
-	@echo "$(GREEN)Building project...$(RESET)"
-	@$(MAKE) -s check-dependencies
-	@$(MAKE) -s install-python-dependencies
-	@$(MAKE) -s install-frontend-dependencies
-	@$(MAKE) -s install-pre-commit-hooks
-	@$(MAKE) -s build-frontend
-	@echo "$(GREEN)Build completed successfully.$(RESET)"
+        @echo "$(GREEN)Building project...$(RESET)"
+        @$(MAKE) -s check-dependencies
+        @$(MAKE) -s install-python-dependencies
+        @$(MAKE) -s install-frontend-dependencies
+        @$(MAKE) -s install-pre-commit-hooks
+        @$(MAKE) -s build-frontend
+        @echo "$(GREEN)Build completed successfully.$(RESET)"
 
 check-dependencies:
-	@echo "$(YELLOW)Checking dependencies...$(RESET)"
-	@$(MAKE) -s check-system
-	@$(MAKE) -s check-python
-	@$(MAKE) -s check-npm
-	@$(MAKE) -s check-nodejs
+        @echo "$(YELLOW)Checking dependencies...$(RESET)"
+        @$(MAKE) -s check-system
+        @$(MAKE) -s check-python
+        @$(MAKE) -s check-npm
+        @$(MAKE) -s check-nodejs
 ifeq ($(INSTALL_DOCKER),)
-	@$(MAKE) -s check-docker
+        @$(MAKE) -s check-docker
 endif
-	@$(MAKE) -s check-poetry
-	@echo "$(GREEN)Dependencies checked successfully.$(RESET)"
+        @$(MAKE) -s check-poetry
+        @echo "$(GREEN)Dependencies checked successfully.$(RESET)"
 
 check-system:
-	@echo "$(YELLOW)Checking system...$(RESET)"
-	@if [ "$(shell uname)" = "Darwin" ]; then \
-		echo "$(BLUE)macOS detected.$(RESET)"; \
-	elif [ "$(shell uname)" = "Linux" ]; then \
-		if [ -f "/etc/manjaro-release" ]; then \
-			echo "$(BLUE)Manjaro Linux detected.$(RESET)"; \
-		else \
-			echo "$(BLUE)Linux detected.$(RESET)"; \
-		fi; \
-	elif [ "$$(uname -r | grep -i microsoft)" ]; then \
-		echo "$(BLUE)Windows Subsystem for Linux detected.$(RESET)"; \
-	else \
-		echo "$(RED)Unsupported system detected. Please use macOS, Linux, or Windows Subsystem for Linux (WSL).$(RESET)"; \
-		exit 1; \
-	fi
+        @echo "$(YELLOW)Checking system...$(RESET)"
+        @if [ "$(shell uname)" = "Darwin" ]; then \
+                echo "$(BLUE)macOS detected.$(RESET)"; \
+        elif [ "$(shell uname)" = "Linux" ]; then \
+                if [ -f "/etc/manjaro-release" ]; then \
+                        echo "$(BLUE)Manjaro Linux detected.$(RESET)"; \
+                else \
+                        echo "$(BLUE)Linux detected.$(RESET)"; \
+                fi; \
+        elif [ "$$(uname -r | grep -i microsoft)" ]; then \
+                echo "$(BLUE)Windows Subsystem for Linux detected.$(RESET)"; \
+        else \
+                echo "$(RED)Unsupported system detected. Please use macOS, Linux, or Windows Subsystem for Linux (WSL).$(RESET)"; \
+                exit 1; \
+        fi
 
 check-python:
-	@echo "$(YELLOW)Checking Python installation...$(RESET)"
-	@if command -v python$(PYTHON_VERSION) > /dev/null; then \
-		echo "$(BLUE)$(shell python$(PYTHON_VERSION) --version) is already installed.$(RESET)"; \
-	else \
-		echo "$(RED)Python $(PYTHON_VERSION) is not installed. Please install Python $(PYTHON_VERSION) to continue.$(RESET)"; \
-		exit 1; \
-	fi
+        @echo "$(YELLOW)Checking Python installation...$(RESET)"
+        @if command -v python$(PYTHON_VERSION) > /dev/null; then \
+                echo "$(BLUE)$(shell python$(PYTHON_VERSION) --version) is already installed.$(RESET)"; \
+        else \
+                echo "$(RED)Python $(PYTHON_VERSION) is not installed. Please install Python $(PYTHON_VERSION) to continue.$(RESET)"; \
+                exit 1; \
+        fi
 
 check-npm:
-	@echo "$(YELLOW)Checking npm installation...$(RESET)"
-	@if command -v npm > /dev/null; then \
-		echo "$(BLUE)npm $(shell npm --version) is already installed.$(RESET)"; \
-	else \
-		echo "$(RED)npm is not installed. Please install Node.js to continue.$(RESET)"; \
-		exit 1; \
-	fi
+        @echo "$(YELLOW)Checking npm installation...$(RESET)"
+        @if command -v npm > /dev/null; then \
+                echo "$(BLUE)npm $(shell npm --version) is already installed.$(RESET)"; \
+        else \
+                echo "$(RED)npm is not installed. Please install Node.js to continue.$(RESET)"; \
+                exit 1; \
+        fi
 
 check-nodejs:
-	@echo "$(YELLOW)Checking Node.js installation...$(RESET)"
-	@if command -v node > /dev/null; then \
-		NODE_VERSION=$(shell node --version | sed -E 's/v//g'); \
-		IFS='.' read -r -a NODE_VERSION_ARRAY <<< "$$NODE_VERSION"; \
-		if [ "$${NODE_VERSION_ARRAY[0]}" -ge 22 ]; then \
-			echo "$(BLUE)Node.js $$NODE_VERSION is already installed.$(RESET)"; \
-		else \
-			echo "$(RED)Node.js 22.x or later is required. Please install Node.js 22.x or later to continue.$(RESET)"; \
-			exit 1; \
-		fi; \
-	else \
-		echo "$(RED)Node.js is not installed. Please install Node.js to continue.$(RESET)"; \
-		exit 1; \
-	fi
+        @echo "$(YELLOW)Checking Node.js installation...$(RESET)"
+        @if command -v node > /dev/null; then \
+                NODE_VERSION=$(shell node --version | sed -E 's/v//g'); \
+                IFS='.' read -r -a NODE_VERSION_ARRAY <<< "$$NODE_VERSION"; \
+                if [ "$${NODE_VERSION_ARRAY[0]}" -ge 22 ]; then \
+                        echo "$(BLUE)Node.js $$NODE_VERSION is already installed.$(RESET)"; \
+                else \
+                        echo "$(RED)Node.js 22.x or later is required. Please install Node.js 22.x or later to continue.$(RESET)"; \
+                        exit 1; \
+                fi; \
+        else \
+                echo "$(RED)Node.js is not installed. Please install Node.js to continue.$(RESET)"; \
+                exit 1; \
+        fi
 
 check-docker:
-	@echo "$(YELLOW)Checking Docker installation...$(RESET)"
-	@if command -v docker > /dev/null; then \
-		echo "$(BLUE)$(shell docker --version) is already installed.$(RESET)"; \
-	else \
-		echo "$(RED)Docker is not installed. Please install Docker to continue.$(RESET)"; \
-		exit 1; \
-	fi
+        @echo "$(YELLOW)Checking Docker installation...$(RESET)"
+        @if command -v docker > /dev/null; then \
+                echo "$(BLUE)$(shell docker --version) is already installed.$(RESET)"; \
+        else \
+                echo "$(RED)Docker is not installed. Please install Docker to continue.$(RESET)"; \
+                exit 1; \
+        fi
 
 check-poetry:
-	@echo "$(YELLOW)Checking Poetry installation...$(RESET)"
-	@if command -v poetry > /dev/null; then \
-		POETRY_VERSION=$(shell poetry --version 2>&1 | sed -E 's/Poetry \(version ([0-9]+\.[0-9]+\.[0-9]+)\)/\1/'); \
-		IFS='.' read -r -a POETRY_VERSION_ARRAY <<< "$$POETRY_VERSION"; \
-		if [ $${POETRY_VERSION_ARRAY[0]} -gt 1 ] || ([ $${POETRY_VERSION_ARRAY[0]} -eq 1 ] && [ $${POETRY_VERSION_ARRAY[1]} -ge 8 ]); then \
-			echo "$(BLUE)$(shell poetry --version) is already installed.$(RESET)"; \
-		else \
-			echo "$(RED)Poetry 1.8 or later is required. You can install poetry by running the following command, then adding Poetry to your PATH:"; \
-			echo "$(RED) curl -sSL https://install.python-poetry.org | python$(PYTHON_VERSION) -$(RESET)"; \
-			echo "$(RED)More detail here: https://python-poetry.org/docs/#installing-with-the-official-installer$(RESET)"; \
-			exit 1; \
-		fi; \
-	else \
-		echo "$(RED)Poetry is not installed. You can install poetry by running the following command, then adding Poetry to your PATH:"; \
-		echo "$(RED) curl -sSL https://install.python-poetry.org | python$(PYTHON_VERSION) -$(RESET)"; \
-		echo "$(RED)More detail here: https://python-poetry.org/docs/#installing-with-the-official-installer$(RESET)"; \
-		exit 1; \
-	fi
+        @echo "$(YELLOW)Checking Poetry installation...$(RESET)"
+        @if command -v poetry > /dev/null; then \
+                POETRY_VERSION=$(shell poetry --version 2>&1 | sed -E 's/Poetry \(version ([0-9]+\.[0-9]+\.[0-9]+)\)/\1/'); \
+                IFS='.' read -r -a POETRY_VERSION_ARRAY <<< "$$POETRY_VERSION"; \
+                if [ $${POETRY_VERSION_ARRAY[0]} -gt 1 ] || ([ $${POETRY_VERSION_ARRAY[0]} -eq 1 ] && [ $${POETRY_VERSION_ARRAY[1]} -ge 8 ]); then \
+                        echo "$(BLUE)$(shell poetry --version) is already installed.$(RESET)"; \
+                else \
+                        echo "$(RED)Poetry 1.8 or later is required. You can install poetry by running the following command, then adding Poetry to your PATH:"; \
+                        echo "$(RED) curl -sSL https://install.python-poetry.org | python$(PYTHON_VERSION) -$(RESET)"; \
+                        echo "$(RED)More detail here: https://python-poetry.org/docs/#installing-with-the-official-installer$(RESET)"; \
+                        exit 1; \
+                fi; \
+        else \
+                echo "$(RED)Poetry is not installed. You can install poetry by running the following command, then adding Poetry to your PATH:"; \
+                echo "$(RED) curl -sSL https://install.python-poetry.org | python$(PYTHON_VERSION) -$(RESET)"; \
+                echo "$(RED)More detail here: https://python-poetry.org/docs/#installing-with-the-official-installer$(RESET)"; \
+                exit 1; \
+        fi
 
 install-python-dependencies:
-	@echo "$(GREEN)Installing Python dependencies...$(RESET)"
-	@if [ -z "${TZ}" ]; then \
-		echo "Defaulting TZ (timezone) to UTC"; \
-		export TZ="UTC"; \
-	fi
-	poetry env use python$(PYTHON_VERSION)
-	@if [ "$(shell uname)" = "Darwin" ]; then \
-		echo "$(BLUE)Installing chroma-hnswlib...$(RESET)"; \
-		export HNSWLIB_NO_NATIVE=1; \
-		poetry run pip install chroma-hnswlib; \
-	fi
-	@poetry install --without llama-index
-	@if [ -f "/etc/manjaro-release" ]; then \
-		echo "$(BLUE)Detected Manjaro Linux. Installing Playwright dependencies...$(RESET)"; \
-		poetry run pip install playwright; \
-		poetry run playwright install chromium; \
-	else \
-		if [ ! -f cache/playwright_chromium_is_installed.txt ]; then \
-			echo "Running playwright install --with-deps chromium..."; \
-			poetry run playwright install --with-deps chromium; \
-			mkdir -p cache; \
-			touch cache/playwright_chromium_is_installed.txt; \
-		else \
-			echo "Setup already done. Skipping playwright installation."; \
-		fi \
-	fi
-	@echo "$(GREEN)Python dependencies installed successfully.$(RESET)"
+        @echo "$(GREEN)Installing Python dependencies...$(RESET)"
+        @if [ -z "${TZ}" ]; then \
+                echo "Defaulting TZ (timezone) to UTC"; \
+                export TZ="UTC"; \
+        fi
+        poetry env use python$(PYTHON_VERSION)
+        @if [ "$(shell uname)" = "Darwin" ]; then \
+                echo "$(BLUE)Installing chroma-hnswlib...$(RESET)"; \
+                export HNSWLIB_NO_NATIVE=1; \
+                poetry run pip install chroma-hnswlib; \
+        fi
+        @poetry install --without llama-index
+        @if [ -f "/etc/manjaro-release" ]; then \
+                echo "$(BLUE)Detected Manjaro Linux. Installing Playwright dependencies...$(RESET)"; \
+                poetry run pip install playwright; \
+                poetry run playwright install chromium; \
+        else \
+                if [ ! -f cache/playwright_chromium_is_installed.txt ]; then \
+                        echo "Running playwright install --with-deps chromium..."; \
+                        poetry run playwright install --with-deps chromium; \
+                        mkdir -p cache; \
+                        touch cache/playwright_chromium_is_installed.txt; \
+                else \
+                        echo "Setup already done. Skipping playwright installation."; \
+                fi \
+        fi
+        @echo "$(GREEN)Python dependencies installed successfully.$(RESET)"
 
 install-frontend-dependencies:
-	@echo "$(YELLOW)Setting up frontend environment...$(RESET)"
-	@echo "$(YELLOW)Detect Node.js version...$(RESET)"
-	@cd frontend && node ./scripts/detect-node-version.js
-	echo "$(BLUE)Installing frontend dependencies with npm...$(RESET)"
-	@cd frontend && npm install
-	@echo "$(GREEN)Frontend dependencies installed successfully.$(RESET)"
+        @echo "$(YELLOW)Setting up frontend environment...$(RESET)"
+        @echo "$(YELLOW)Detect Node.js version...$(RESET)"
+        @cd frontend && node ./scripts/detect-node-version.js
+        echo "$(BLUE)Installing frontend dependencies with npm...$(RESET)"
+        @cd frontend && npm install
+        @echo "$(GREEN)Frontend dependencies installed successfully.$(RESET)"
 
 install-pre-commit-hooks:
-	@echo "$(YELLOW)Installing pre-commit hooks...$(RESET)"
-	@git config --unset-all core.hooksPath || true
-	@poetry run pre-commit install --config $(PRE_COMMIT_CONFIG_PATH)
-	@echo "$(GREEN)Pre-commit hooks installed successfully.$(RESET)"
+        @echo "$(YELLOW)Installing pre-commit hooks...$(RESET)"
+        @git config --unset-all core.hooksPath || true
+        @poetry run pre-commit install --config $(PRE_COMMIT_CONFIG_PATH)
+        @echo "$(GREEN)Pre-commit hooks installed successfully.$(RESET)"
 
 lint-backend:
-	@echo "$(YELLOW)Running linters...$(RESET)"
-	@poetry run pre-commit run --files openhands/**/* agenthub/**/* evaluation/**/* --show-diff-on-failure --config $(PRE_COMMIT_CONFIG_PATH)
+        @echo "$(YELLOW)Running linters...$(RESET)"
+        @poetry run pre-commit run --files openhands/**/* agenthub/**/* evaluation/**/* --show-diff-on-failure --config $(PRE_COMMIT_CONFIG_PATH)
 
 lint-frontend:
-	@echo "$(YELLOW)Running linters for frontend...$(RESET)"
-	@cd frontend && npm run lint
+        @echo "$(YELLOW)Running linters for frontend...$(RESET)"
+        @cd frontend && npm run lint
 
 lint:
-	@$(MAKE) -s lint-frontend
-	@$(MAKE) -s lint-backend
+        @$(MAKE) -s lint-frontend
+        @$(MAKE) -s lint-backend
 
 test-frontend:
-	@echo "$(YELLOW)Running tests for frontend...$(RESET)"
-	@cd frontend && npm run test
+        @echo "$(YELLOW)Running tests for frontend...$(RESET)"
+        @cd frontend && npm run test
 
 test:
-	@$(MAKE) -s test-frontend
+        @$(MAKE) -s test-frontend
 
 build-frontend:
-	@echo "$(YELLOW)Building frontend...$(RESET)"
-	@cd frontend && npm run build
+        @echo "$(YELLOW)Building frontend...$(RESET)"
+        @cd frontend && npm run build
+
+build-bolt-diy:
+        @echo "$(YELLOW)Building bolt.diy frontend...$(RESET)"
+        @if [ ! -d "bolt_diy" ]; then \
+                echo "$(YELLOW)Cloning bolt.diy repository...$(RESET)"; \
+                git clone https://github.com/stackblitz-labs/bolt.diy.git bolt_diy; \
+        fi
+        @echo "$(YELLOW)Patching bolt.diy to work with OpenHands...$(RESET)"
+        @./scripts/patch_bolt_diy.sh
+        @cd bolt_diy && npm install && npm run build
+        @echo "$(GREEN)bolt.diy frontend built successfully.$(RESET)"
 
 # Start backend
 start-backend:
-	@echo "$(YELLOW)Starting backend...$(RESET)"
-	@poetry run uvicorn openhands.server.listen:app --host $(BACKEND_HOST) --port $(BACKEND_PORT) --reload --reload-exclude "./workspace"
+        @echo "$(YELLOW)Starting backend with $(FRONTEND_TYPE) frontend...$(RESET)"
+        @OPENHANDS_FRONTEND_TYPE=$(FRONTEND_TYPE) poetry run uvicorn openhands.server.listen:app --host $(BACKEND_HOST) --port $(BACKEND_PORT) --reload --reload-exclude "./workspace"
 
 # Start frontend
 start-frontend:
-	@echo "$(YELLOW)Starting frontend...$(RESET)"
-	@cd frontend && VITE_BACKEND_HOST=$(BACKEND_HOST_PORT) VITE_FRONTEND_PORT=$(FRONTEND_PORT) npm run dev -- --port $(FRONTEND_PORT) --host $(BACKEND_HOST)
+        @echo "$(YELLOW)Starting frontend...$(RESET)"
+        @cd frontend && VITE_BACKEND_HOST=$(BACKEND_HOST_PORT) VITE_FRONTEND_PORT=$(FRONTEND_PORT) npm run dev -- --port $(FRONTEND_PORT) --host $(BACKEND_HOST)
 
 # Common setup for running the app (non-callable)
 _run_setup:
-	@if [ "$(OS)" = "Windows_NT" ]; then \
-		echo "$(RED) Windows is not supported, use WSL instead!$(RESET)"; \
-		exit 1; \
-	fi
-	@mkdir -p logs
-	@echo "$(YELLOW)Starting backend server...$(RESET)"
-	@poetry run uvicorn openhands.server.listen:app --host $(BACKEND_HOST) --port $(BACKEND_PORT) &
-	@echo "$(YELLOW)Waiting for the backend to start...$(RESET)"
-	@until nc -z localhost $(BACKEND_PORT); do sleep 0.1; done
-	@echo "$(GREEN)Backend started successfully.$(RESET)"
+        @if [ "$(OS)" = "Windows_NT" ]; then \
+                echo "$(RED) Windows is not supported, use WSL instead!$(RESET)"; \
+                exit 1; \
+        fi
+        @mkdir -p logs
+        @echo "$(YELLOW)Starting backend server...$(RESET)"
+        @poetry run uvicorn openhands.server.listen:app --host $(BACKEND_HOST) --port $(BACKEND_PORT) &
+        @echo "$(YELLOW)Waiting for the backend to start...$(RESET)"
+        @until nc -z localhost $(BACKEND_PORT); do sleep 0.1; done
+        @echo "$(GREEN)Backend started successfully.$(RESET)"
 
 # Run the app (standard mode)
 run:
-	@echo "$(YELLOW)Running the app...$(RESET)"
-	@$(MAKE) -s _run_setup
-	@$(MAKE) -s start-frontend
-	@echo "$(GREEN)Application started successfully.$(RESET)"
+        @echo "$(YELLOW)Running the app with $(FRONTEND_TYPE) frontend...$(RESET)"
+        @if [ "$(FRONTEND_TYPE)" = "BOLT_DIY" ]; then \
+                $(MAKE) -s build-bolt-diy; \
+        fi
+        @$(MAKE) -s _run_setup
+        @if [ "$(FRONTEND_TYPE)" = "DEFAULT" ]; then \
+                $(MAKE) -s start-frontend; \
+        else \
+                echo "$(GREEN)Using bolt.diy frontend. No need to start the frontend separately.$(RESET)"; \
+        fi
+        @echo "$(GREEN)Application started successfully.$(RESET)"
 
 # Run the app (in docker)
 docker-run: WORKSPACE_BASE ?= $(PWD)/workspace
 docker-run:
-	@if [ -f /.dockerenv ]; then \
-		echo "Running inside a Docker container. Exiting..."; \
-		exit 0; \
-	else \
-		echo "$(YELLOW)Running the app in Docker $(OPTIONS)...$(RESET)"; \
-		export WORKSPACE_BASE=${WORKSPACE_BASE}; \
-		export SANDBOX_USER_ID=$(shell id -u); \
-		export DATE=$(shell date +%Y%m%d%H%M%S); \
-		docker compose up $(OPTIONS); \
-	fi
+        @if [ -f /.dockerenv ]; then \
+                echo "Running inside a Docker container. Exiting..."; \
+                exit 0; \
+        else \
+                echo "$(YELLOW)Running the app in Docker $(OPTIONS)...$(RESET)"; \
+                export WORKSPACE_BASE=${WORKSPACE_BASE}; \
+                export SANDBOX_USER_ID=$(shell id -u); \
+                export DATE=$(shell date +%Y%m%d%H%M%S); \
+                docker compose up $(OPTIONS); \
+        fi
 
 # Run the app (WSL mode)
 run-wsl:
-	@echo "$(YELLOW)Running the app in WSL mode...$(RESET)"
-	@$(MAKE) -s _run_setup
-	@cd frontend && echo "$(BLUE)Starting frontend with npm (WSL mode)...$(RESET)" && npm run dev_wsl -- --port $(FRONTEND_PORT)
-	@echo "$(GREEN)Application started successfully in WSL mode.$(RESET)"
+        @echo "$(YELLOW)Running the app in WSL mode...$(RESET)"
+        @$(MAKE) -s _run_setup
+        @cd frontend && echo "$(BLUE)Starting frontend with npm (WSL mode)...$(RESET)" && npm run dev_wsl -- --port $(FRONTEND_PORT)
+        @echo "$(GREEN)Application started successfully in WSL mode.$(RESET)"
 
 # Setup config.toml
 setup-config:
-	@echo "$(YELLOW)Setting up config.toml...$(RESET)"
-	@$(MAKE) setup-config-prompts
-	@mv $(CONFIG_FILE).tmp $(CONFIG_FILE)
-	@echo "$(GREEN)Config.toml setup completed.$(RESET)"
+        @echo "$(YELLOW)Setting up config.toml...$(RESET)"
+        @$(MAKE) setup-config-prompts
+        @mv $(CONFIG_FILE).tmp $(CONFIG_FILE)
+        @echo "$(GREEN)Config.toml setup completed.$(RESET)"
 
 setup-config-prompts:
-	@echo "[core]" > $(CONFIG_FILE).tmp
+        @echo "[core]" > $(CONFIG_FILE).tmp
 
-	@read -p "Enter your workspace directory (as absolute path) [default: $(DEFAULT_WORKSPACE_DIR)]: " workspace_dir; \
-	 workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \
-	 echo "workspace_base=\"$$workspace_dir\"" >> $(CONFIG_FILE).tmp
+        @read -p "Enter your workspace directory (as absolute path) [default: $(DEFAULT_WORKSPACE_DIR)]: " workspace_dir; \
+         workspace_dir=$${workspace_dir:-$(DEFAULT_WORKSPACE_DIR)}; \
+         echo "workspace_base=\"$$workspace_dir\"" >> $(CONFIG_FILE).tmp
 
-	@echo "" >> $(CONFIG_FILE).tmp
+        @echo "" >> $(CONFIG_FILE).tmp
 
-	@echo "[llm]" >> $(CONFIG_FILE).tmp
-	@read -p "Enter your LLM model name, used for running without UI. Set the model in the UI after you start the app. (see https://docs.litellm.ai/docs/providers for full list) [default: $(DEFAULT_MODEL)]: " llm_model; \
-	 llm_model=$${llm_model:-$(DEFAULT_MODEL)}; \
-	 echo "model=\"$$llm_model\"" >> $(CONFIG_FILE).tmp
+        @echo "[llm]" >> $(CONFIG_FILE).tmp
+        @read -p "Enter your LLM model name, used for running without UI. Set the model in the UI after you start the app. (see https://docs.litellm.ai/docs/providers for full list) [default: $(DEFAULT_MODEL)]: " llm_model; \
+         llm_model=$${llm_model:-$(DEFAULT_MODEL)}; \
+         echo "model=\"$$llm_model\"" >> $(CONFIG_FILE).tmp
 
-	@read -p "Enter your LLM api key: " llm_api_key; \
-	 echo "api_key=\"$$llm_api_key\"" >> $(CONFIG_FILE).tmp
+        @read -p "Enter your LLM api key: " llm_api_key; \
+         echo "api_key=\"$$llm_api_key\"" >> $(CONFIG_FILE).tmp
 
-	@read -p "Enter your LLM base URL [mostly used for local LLMs, leave blank if not needed - example: http://localhost:5001/v1/]: " llm_base_url; \
-	 if [[ ! -z "$$llm_base_url" ]]; then echo "base_url=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; fi
+        @read -p "Enter your LLM base URL [mostly used for local LLMs, leave blank if not needed - example: http://localhost:5001/v1/]: " llm_base_url; \
+         if [[ ! -z "$$llm_base_url" ]]; then echo "base_url=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; fi
 
-	@echo "Enter your LLM Embedding Model"; \
-		echo "Choices are:"; \
-		echo "  - openai"; \
-		echo "  - azureopenai"; \
-		echo "  - Embeddings available only with OllamaEmbedding:"; \
-		echo "    - llama2"; \
-		echo "    - mxbai-embed-large"; \
-		echo "    - nomic-embed-text"; \
-		echo "    - all-minilm"; \
-		echo "    - stable-code"; \
-		echo "    - bge-m3"; \
-		echo "    - bge-large"; \
-		echo "    - paraphrase-multilingual"; \
-		echo "    - snowflake-arctic-embed"; \
-		echo "  - Leave blank to default to 'BAAI/bge-small-en-v1.5' via huggingface"; \
-		read -p "> " llm_embedding_model; \
-		echo "embedding_model=\"$$llm_embedding_model\"" >> $(CONFIG_FILE).tmp; \
-		if [ "$$llm_embedding_model" = "llama2" ] || [ "$$llm_embedding_model" = "mxbai-embed-large" ] || [ "$$llm_embedding_model" = "nomic-embed-text" ] || [ "$$llm_embedding_model" = "all-minilm" ] || [ "$$llm_embedding_model" = "stable-code" ]; then \
-			read -p "Enter the local model URL for the embedding model (will set llm.embedding_base_url): " llm_embedding_base_url; \
-				echo "embedding_base_url=\"$$llm_embedding_base_url\"" >> $(CONFIG_FILE).tmp; \
-		elif [ "$$llm_embedding_model" = "azureopenai" ]; then \
-			read -p "Enter the Azure endpoint URL (will overwrite llm.base_url): " llm_base_url; \
-				echo "base_url=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
-			read -p "Enter the Azure LLM Embedding Deployment Name: " llm_embedding_deployment_name; \
-				echo "embedding_deployment_name=\"$$llm_embedding_deployment_name\"" >> $(CONFIG_FILE).tmp; \
-			read -p "Enter the Azure API Version: " llm_api_version; \
-				echo "api_version=\"$$llm_api_version\"" >> $(CONFIG_FILE).tmp; \
-		fi
+        @echo "Enter your LLM Embedding Model"; \
+                echo "Choices are:"; \
+                echo "  - openai"; \
+                echo "  - azureopenai"; \
+                echo "  - Embeddings available only with OllamaEmbedding:"; \
+                echo "    - llama2"; \
+                echo "    - mxbai-embed-large"; \
+                echo "    - nomic-embed-text"; \
+                echo "    - all-minilm"; \
+                echo "    - stable-code"; \
+                echo "    - bge-m3"; \
+                echo "    - bge-large"; \
+                echo "    - paraphrase-multilingual"; \
+                echo "    - snowflake-arctic-embed"; \
+                echo "  - Leave blank to default to 'BAAI/bge-small-en-v1.5' via huggingface"; \
+                read -p "> " llm_embedding_model; \
+                echo "embedding_model=\"$$llm_embedding_model\"" >> $(CONFIG_FILE).tmp; \
+                if [ "$$llm_embedding_model" = "llama2" ] || [ "$$llm_embedding_model" = "mxbai-embed-large" ] || [ "$$llm_embedding_model" = "nomic-embed-text" ] || [ "$$llm_embedding_model" = "all-minilm" ] || [ "$$llm_embedding_model" = "stable-code" ]; then \
+                        read -p "Enter the local model URL for the embedding model (will set llm.embedding_base_url): " llm_embedding_base_url; \
+                                echo "embedding_base_url=\"$$llm_embedding_base_url\"" >> $(CONFIG_FILE).tmp; \
+                elif [ "$$llm_embedding_model" = "azureopenai" ]; then \
+                        read -p "Enter the Azure endpoint URL (will overwrite llm.base_url): " llm_base_url; \
+                                echo "base_url=\"$$llm_base_url\"" >> $(CONFIG_FILE).tmp; \
+                        read -p "Enter the Azure LLM Embedding Deployment Name: " llm_embedding_deployment_name; \
+                                echo "embedding_deployment_name=\"$$llm_embedding_deployment_name\"" >> $(CONFIG_FILE).tmp; \
+                        read -p "Enter the Azure API Version: " llm_api_version; \
+                                echo "api_version=\"$$llm_api_version\"" >> $(CONFIG_FILE).tmp; \
+                fi
 
 
 # Develop in container
 docker-dev:
-	@if [ -f /.dockerenv ]; then \
-		echo "Running inside a Docker container. Exiting..."; \
-		exit 0; \
-	else \
-		echo "$(YELLOW)Build and run in Docker $(OPTIONS)...$(RESET)"; \
-		./containers/dev/dev.sh $(OPTIONS); \
-	fi
+        @if [ -f /.dockerenv ]; then \
+                echo "Running inside a Docker container. Exiting..."; \
+                exit 0; \
+        else \
+                echo "$(YELLOW)Build and run in Docker $(OPTIONS)...$(RESET)"; \
+                ./containers/dev/dev.sh $(OPTIONS); \
+        fi
 
 # Clean up all caches
 clean:
-	@echo "$(YELLOW)Cleaning up caches...$(RESET)"
-	@rm -rf openhands/.cache
-	@echo "$(GREEN)Caches cleaned up successfully.$(RESET)"
+        @echo "$(YELLOW)Cleaning up caches...$(RESET)"
+        @rm -rf openhands/.cache
+        @echo "$(GREEN)Caches cleaned up successfully.$(RESET)"
 
 # Help
 help:
-	@echo "$(BLUE)Usage: make [target]$(RESET)"
-	@echo "Targets:"
-	@echo "  $(GREEN)build$(RESET)               - Build project, including environment setup and dependencies."
-	@echo "  $(GREEN)lint$(RESET)                - Run linters on the project."
-	@echo "  $(GREEN)setup-config$(RESET)        - Setup the configuration for OpenHands by providing LLM API key,"
-	@echo "                        LLM Model name, and workspace directory."
-	@echo "  $(GREEN)start-backend$(RESET)       - Start the backend server for the OpenHands project."
-	@echo "  $(GREEN)start-frontend$(RESET)      - Start the frontend server for the OpenHands project."
-	@echo "  $(GREEN)run$(RESET)                 - Run the OpenHands application, starting both backend and frontend servers."
-	@echo "                        Backend Log file will be stored in the 'logs' directory."
-	@echo "  $(GREEN)docker-dev$(RESET)          - Build and run the OpenHands application in Docker."
-	@echo "  $(GREEN)docker-run$(RESET)          - Run the OpenHands application, starting both backend and frontend servers in Docker."
-	@echo "  $(GREEN)help$(RESET)                - Display this help message, providing information on available targets."
+        @echo "$(BLUE)Usage: make [target] [FRONTEND_TYPE=DEFAULT|BOLT_DIY]$(RESET)"
+        @echo "Targets:"
+        @echo "  $(GREEN)build$(RESET)               - Build project, including environment setup and dependencies."
+        @echo "  $(GREEN)lint$(RESET)                - Run linters on the project."
+        @echo "  $(GREEN)setup-config$(RESET)        - Setup the configuration for OpenHands by providing LLM API key,"
+        @echo "                        LLM Model name, and workspace directory."
+        @echo "  $(GREEN)start-backend$(RESET)       - Start the backend server for the OpenHands project."
+        @echo "  $(GREEN)start-frontend$(RESET)      - Start the frontend server for the OpenHands project."
+        @echo "  $(GREEN)build-bolt-diy$(RESET)      - Clone and build the bolt.diy frontend."
+        @echo "  $(GREEN)run$(RESET)                 - Run the OpenHands application, starting both backend and frontend servers."
+        @echo "                        Backend Log file will be stored in the 'logs' directory."
+        @echo "                        Use FRONTEND_TYPE=BOLT_DIY to use the bolt.diy frontend."
+        @echo "  $(GREEN)docker-dev$(RESET)          - Build and run the OpenHands application in Docker."
+        @echo "  $(GREEN)docker-run$(RESET)          - Run the OpenHands application, starting both backend and frontend servers in Docker."
+        @echo "  $(GREEN)help$(RESET)                - Display this help message, providing information on available targets."
 
 # Phony targets
-.PHONY: build check-dependencies check-python check-npm check-docker check-poetry install-python-dependencies install-frontend-dependencies install-pre-commit-hooks lint start-backend start-frontend run run-wsl setup-config setup-config-prompts help
+.PHONY: build check-dependencies check-python check-npm check-docker check-poetry install-python-dependencies install-frontend-dependencies install-pre-commit-hooks lint start-backend start-frontend build-bolt-diy run run-wsl setup-config setup-config-prompts help
 .PHONY: docker-dev docker-run

--- a/README.md
+++ b/README.md
@@ -58,6 +58,29 @@ docker run -it --rm --pull=always \
 
 You'll find OpenHands running at [http://localhost:3000](http://localhost:3000)!
 
+### Alternative Frontend
+
+OpenHands now supports an alternative frontend based on [bolt.diy](https://github.com/stackblitz-labs/bolt.diy). To use it:
+
+1. Clone the repository and build the project:
+   ```bash
+   git clone https://github.com/All-Hands-AI/OpenHands.git
+   cd OpenHands
+   make build
+   ```
+
+2. Build the bolt.diy frontend:
+   ```bash
+   make build-bolt-diy
+   ```
+
+3. Run OpenHands with the bolt.diy frontend:
+   ```bash
+   make run FRONTEND_TYPE=BOLT_DIY
+   ```
+
+You can switch between the default frontend and bolt.diy by setting the `FRONTEND_TYPE` environment variable to either `DEFAULT` or `BOLT_DIY`.
+
 Finally, you'll need a model provider and API key.
 [Anthropic's Claude 3.5 Sonnet](https://www.anthropic.com/api) (`anthropic/claude-3-5-sonnet-20241022`)
 works best, but you have [many options](https://docs.all-hands.dev/modules/usage/llms).

--- a/config.template.toml
+++ b/config.template.toml
@@ -29,6 +29,9 @@ workspace_base = "./workspace"
 # Cache directory path
 #cache_dir = "/tmp/cache"
 
+# Frontend type (DEFAULT or BOLT_DIY)
+#frontend_type = "DEFAULT"
+
 # Reasoning effort for o1 models (low, medium, high, or not set)
 #reasoning_effort = "medium"
 

--- a/docs/bolt_diy_frontend.md
+++ b/docs/bolt_diy_frontend.md
@@ -1,0 +1,110 @@
+# Using bolt.diy as an Alternative Frontend for OpenHands
+
+OpenHands now supports [bolt.diy](https://github.com/stackblitz-labs/bolt.diy) as an alternative frontend. bolt.diy is a powerful AI-powered web development environment that allows you to create full-stack web applications using natural language prompts.
+
+## Features
+
+- AI-powered full-stack web development for NodeJS-based applications
+- Support for multiple LLMs with an extensible architecture
+- Attach images to prompts for better contextual understanding
+- Integrated terminal to view output of LLM-run commands
+- Revert code to earlier versions for easier debugging
+- Download projects as ZIP for easy portability
+- Deploy directly to Netlify
+
+## Setup
+
+### Prerequisites
+
+- Node.js (LTS version recommended)
+- npm or pnpm
+- Git
+
+### Building the bolt.diy Frontend
+
+1. Clone the OpenHands repository:
+   ```bash
+   git clone https://github.com/All-Hands-AI/OpenHands.git
+   cd OpenHands
+   ```
+
+2. Build the OpenHands project:
+   ```bash
+   make build
+   ```
+
+3. Build the bolt.diy frontend:
+   ```bash
+   make build-bolt-diy
+   ```
+
+This will clone the bolt.diy repository, patch it to work with OpenHands, and build the frontend.
+
+## Running OpenHands with bolt.diy
+
+To run OpenHands with the bolt.diy frontend:
+
+```bash
+make run FRONTEND_TYPE=BOLT_DIY
+```
+
+This will start the OpenHands backend and serve the bolt.diy frontend.
+
+## Configuration
+
+You can configure which frontend to use in several ways:
+
+1. Using the `FRONTEND_TYPE` environment variable:
+   ```bash
+   export FRONTEND_TYPE=BOLT_DIY
+   make run
+   ```
+
+2. Passing it as a parameter to the `make run` command:
+   ```bash
+   make run FRONTEND_TYPE=BOLT_DIY
+   ```
+
+3. Setting it in your `config.toml` file:
+   ```toml
+   [core]
+   frontend_type = "BOLT_DIY"
+   ```
+
+## Switching Between Frontends
+
+You can easily switch between the default OpenHands frontend and bolt.diy:
+
+- For the default frontend:
+  ```bash
+  make run FRONTEND_TYPE=DEFAULT
+  ```
+
+- For the bolt.diy frontend:
+  ```bash
+  make run FRONTEND_TYPE=BOLT_DIY
+  ```
+
+## Troubleshooting
+
+If you encounter issues with the bolt.diy frontend:
+
+1. Make sure you have built the bolt.diy frontend:
+   ```bash
+   make build-bolt-diy
+   ```
+
+2. Check that the patching process completed successfully:
+   ```bash
+   ./scripts/patch_bolt_diy.sh
+   ```
+
+3. If you're still having issues, try rebuilding the bolt.diy frontend:
+   ```bash
+   rm -rf bolt_diy
+   make build-bolt-diy
+   ```
+
+## Contributing
+
+If you'd like to improve the bolt.diy integration, please submit a pull request with your changes. Make sure to test your changes with both frontends to ensure compatibility.

--- a/openhands/server/config/server_config.py
+++ b/openhands/server/config/server_config.py
@@ -1,8 +1,14 @@
 import os
+from enum import Enum, auto
 
 from openhands.core.logger import openhands_logger as logger
 from openhands.server.types import AppMode, ServerConfigInterface
 from openhands.utils.import_utils import get_impl
+
+
+class FrontendType(Enum):
+    DEFAULT = auto()
+    BOLT_DIY = auto()
 
 
 class ServerConfig(ServerConfigInterface):
@@ -18,6 +24,7 @@ class ServerConfig(ServerConfigInterface):
     )
     conversation_manager_class: str = 'openhands.server.conversation_manager.standalone_conversation_manager.StandaloneConversationManager'
     monitoring_listener_class: str = 'openhands.server.monitoring.MonitoringListener'
+    frontend_type = FrontendType.DEFAULT
 
     def verify_config(self):
         if self.config_cls:
@@ -28,6 +35,7 @@ class ServerConfig(ServerConfigInterface):
             'APP_MODE': self.app_mode,
             'GITHUB_CLIENT_ID': self.github_client_id,
             'POSTHOG_CLIENT_KEY': self.posthog_client_key,
+            'FRONTEND_TYPE': self.frontend_type.name,
         }
 
         return config

--- a/openhands/server/frontend_manager.py
+++ b/openhands/server/frontend_manager.py
@@ -1,0 +1,79 @@
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from openhands.core.logger import openhands_logger as logger
+from openhands.server.config.server_config import FrontendType
+
+
+class FrontendManager:
+    """
+    Manages the frontend selection and building process.
+    """
+
+    DEFAULT_FRONTEND_DIR = './frontend/build'
+    BOLT_DIY_REPO = 'https://github.com/stackblitz-labs/bolt.diy.git'
+    BOLT_DIY_DIR = './bolt_diy'
+    BOLT_DIY_BUILD_DIR = './bolt_diy/dist'
+
+    @classmethod
+    def get_frontend_directory(cls, frontend_type: FrontendType) -> str:
+        """
+        Returns the directory path for the selected frontend.
+        
+        Args:
+            frontend_type: The type of frontend to use
+            
+        Returns:
+            The directory path for the selected frontend
+        """
+        if frontend_type == FrontendType.DEFAULT:
+            return cls.DEFAULT_FRONTEND_DIR
+        elif frontend_type == FrontendType.BOLT_DIY:
+            # Ensure bolt.diy is cloned and built
+            if not os.path.exists(cls.BOLT_DIY_BUILD_DIR):
+                cls.setup_bolt_diy()
+            return cls.BOLT_DIY_BUILD_DIR
+        else:
+            logger.warning(f"Unknown frontend type: {frontend_type}. Using default.")
+            return cls.DEFAULT_FRONTEND_DIR
+
+    @classmethod
+    def setup_bolt_diy(cls) -> None:
+        """
+        Clones and builds the bolt.diy frontend if it doesn't exist.
+        """
+        logger.info("Setting up bolt.diy frontend...")
+        
+        # Clone the repository if it doesn't exist
+        if not os.path.exists(cls.BOLT_DIY_DIR):
+            logger.info(f"Cloning bolt.diy repository from {cls.BOLT_DIY_REPO}...")
+            try:
+                subprocess.run(
+                    ["git", "clone", cls.BOLT_DIY_REPO, cls.BOLT_DIY_DIR],
+                    check=True,
+                )
+                logger.info("bolt.diy repository cloned successfully.")
+            except subprocess.CalledProcessError as e:
+                logger.error(f"Failed to clone bolt.diy repository: {e}")
+                raise RuntimeError(f"Failed to clone bolt.diy repository: {e}")
+        
+        # Build the frontend
+        logger.info("Building bolt.diy frontend...")
+        try:
+            # Change to the bolt.diy directory
+            cwd = os.getcwd()
+            os.chdir(cls.BOLT_DIY_DIR)
+            
+            # Install dependencies and build
+            subprocess.run(["npm", "install"], check=True)
+            subprocess.run(["npm", "run", "build"], check=True)
+            
+            # Change back to the original directory
+            os.chdir(cwd)
+            
+            logger.info("bolt.diy frontend built successfully.")
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to build bolt.diy frontend: {e}")
+            raise RuntimeError(f"Failed to build bolt.diy frontend: {e}")

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -1,6 +1,10 @@
+import os
 import socketio
 
+from openhands.core.logger import openhands_logger as logger
 from openhands.server.app import app as base_app
+from openhands.server.config.server_config import FrontendType, load_server_config
+from openhands.server.frontend_manager import FrontendManager
 from openhands.server.listen_socket import sio
 from openhands.server.middleware import (
     AttachConversationMiddleware,
@@ -12,8 +16,23 @@ from openhands.server.middleware import (
 )
 from openhands.server.static import SPAStaticFiles
 
+# Load server configuration
+server_config = load_server_config()
+
+# Get frontend type from environment variable or use default
+frontend_type_str = os.environ.get('OPENHANDS_FRONTEND_TYPE', 'DEFAULT')
+try:
+    frontend_type = FrontendType[frontend_type_str]
+except (KeyError, ValueError):
+    logger.warning(f"Unknown frontend type: {frontend_type_str}. Using default.")
+    frontend_type = FrontendType.DEFAULT
+
+# Get the appropriate frontend directory
+frontend_directory = FrontendManager.get_frontend_directory(frontend_type)
+
+# Mount the frontend
 base_app.mount(
-    '/', SPAStaticFiles(directory='./frontend/build', html=True), name='dist'
+    '/', SPAStaticFiles(directory=frontend_directory, html=True), name='dist'
 )
 
 base_app.add_middleware(

--- a/openhands/server/types.py
+++ b/openhands/server/types.py
@@ -20,6 +20,7 @@ class ServerConfigInterface(ABC):
     POSTHOG_CLIENT_KEY: ClassVar[str]
     GITHUB_CLIENT_ID: ClassVar[str]
     ATTACH_SESSION_MIDDLEWARE_PATH: ClassVar[str]
+    FRONTEND_TYPE: ClassVar[str]
 
     @abstractmethod
     def verify_config(self) -> None:
@@ -27,7 +28,7 @@ class ServerConfigInterface(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def get_config(self) -> dict[str, str]:
+    def get_config(self) -> dict[str, any]:
         """Configure attributes for frontend"""
         raise NotImplementedError
 

--- a/scripts/patch_bolt_diy.sh
+++ b/scripts/patch_bolt_diy.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# This script patches the bolt.diy frontend to work with OpenHands
+
+set -e
+
+BOLT_DIY_DIR="./bolt_diy"
+
+if [ ! -d "$BOLT_DIY_DIR" ]; then
+    echo "Error: bolt.diy directory not found. Please run 'make build-bolt-diy' first."
+    exit 1
+fi
+
+echo "Patching bolt.diy frontend to work with OpenHands..."
+
+# Create a patch file for the vite.config.ts to ensure it works with OpenHands API
+cat > /tmp/vite_config_patch.diff << 'EOL'
+--- vite.config.ts.orig	2023-01-01 00:00:00.000000000 +0000
++++ vite.config.ts	2023-01-01 00:00:00.000000000 +0000
+@@ -33,6 +33,7 @@
+       port: FE_PORT,
+       proxy: {
+         "/api": {
++          rewrite: (path) => path.replace(/^\/api/, ''),
+           target: API_URL,
+           changeOrigin: true,
+           secure: !INSECURE_SKIP_VERIFY,
+EOL
+
+# Apply the patch
+cd "$BOLT_DIY_DIR"
+cp vite.config.ts vite.config.ts.orig
+patch -p0 < /tmp/vite_config_patch.diff
+
+# Create a patch for the API client to work with OpenHands
+cat > /tmp/api_client_patch.diff << 'EOL'
+--- app/lib/.server/api/client.ts.orig	2023-01-01 00:00:00.000000000 +0000
++++ app/lib/.server/api/client.ts	2023-01-01 00:00:00.000000000 +0000
+@@ -1,6 +1,6 @@
+ import { json } from '@remix-run/server-runtime';
+ 
+-const API_URL = 'http://localhost:3000';
++const API_URL = '';
+ 
+ export async function apiClient(
+   path: string,
+EOL
+
+# Find the API client file and apply the patch
+API_CLIENT_FILE=$(find app -name "client.ts" -path "*/api/*" | head -n 1)
+if [ -n "$API_CLIENT_FILE" ]; then
+    cp "$API_CLIENT_FILE" "$API_CLIENT_FILE.orig"
+    patch -p0 "$API_CLIENT_FILE" < /tmp/api_client_patch.diff
+    echo "Patched API client file: $API_CLIENT_FILE"
+else
+    echo "Warning: Could not find API client file to patch"
+fi
+
+# Create a patch for the git integration to work with OpenHands
+cat > /tmp/git_integration_patch.diff << 'EOL'
+--- app/lib/.server/git/integration.ts.orig	2023-01-01 00:00:00.000000000 +0000
++++ app/lib/.server/git/integration.ts	2023-01-01 00:00:00.000000000 +0000
+@@ -1,6 +1,6 @@
+ import { json } from '@remix-run/server-runtime';
+ 
+-const API_URL = 'http://localhost:3000';
++const API_URL = '';
+ 
+ export async function gitClient(
+   path: string,
+EOL
+
+# Find the git integration file and apply the patch
+GIT_INTEGRATION_FILE=$(find app -name "integration.ts" -path "*/git/*" | head -n 1)
+if [ -n "$GIT_INTEGRATION_FILE" ]; then
+    cp "$GIT_INTEGRATION_FILE" "$GIT_INTEGRATION_FILE.orig"
+    patch -p0 "$GIT_INTEGRATION_FILE" < /tmp/git_integration_patch.diff
+    echo "Patched git integration file: $GIT_INTEGRATION_FILE"
+else
+    echo "Warning: Could not find git integration file to patch"
+fi
+
+# Return to the original directory
+cd - > /dev/null
+
+echo "Patching completed successfully."


### PR DESCRIPTION
This PR adds support for using bolt.diy as an optional frontend for OpenHands. Users can now choose between the default frontend and bolt.diy.

## Changes

- Added a new `FrontendType` enum to select the frontend type
- Created a `FrontendManager` class to handle frontend selection and building
- Added Makefile targets for building and running with bolt.diy
- Added documentation for using bolt.diy with OpenHands
- Created a patch script to make bolt.diy work with OpenHands API

## How to Use

To use bolt.diy as the frontend:

```bash
make build-bolt-diy
make run FRONTEND_TYPE=BOLT_DIY
```

To switch back to the default frontend:

```bash
make run FRONTEND_TYPE=DEFAULT
```